### PR TITLE
Updating swagger spec

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1,71 +1,66 @@
 openapi: 3.0.1
 info:
   title: Facility Codes
-  description: |-
-    A common API to provide the details of a facility used in international trade comprising of the BIC Container Facilities and SMDG Terminal Codes, these codes are managed under the ownership of each orgainsation independantly but provided under a single API to industry.
-    Bureau International des Containers (BIC) are responsible for providing the inland container facilities within a country, or location.
-    SMDG are responsible for providing the terminals that container vessels call at within a country or location.
-    Both codes are an extension of the UN/LOCODE designed to give granularity of facilities contained within the area identified by the UN/LOCODE.
-  version: 1.0.3
+  description: >-
+    A common API to provide the details of a facility used in International
+    trade comprising of the BIC Container Facilities and SMDG Terminal Codes,
+    these codes are managed under the ownership of each organisation
+    independently but provided under a single API to industry. Bureau
+    International des Containers (BIC) are responsible for providing the inland
+    container facilities within a country, or location. SMDG are responsible for
+    providing the terminals that container vessels call at within a country or
+    location. Both codes are an extension of the UN/LOCODE designed to give
+    granularity of facilities contained within the area identified by the
+    UN/LOCODE.
+  version: "1.0.4-oas3"
 servers:
-- url: https://a0c81nimq5.execute-api.eu-west-1.amazonaws.com/{basePath}
-  variables:
-    basePath:
-      default: BETA
+  - url: 'https://a0c81nimq5.execute-api.eu-west-1.amazonaws.com/{basePath}'
+    variables:
+      basePath:
+        default: BETA
 paths:
-  /facilities/byCountry/{countryCode}/{codeProvider}:
+  '/facilities/byCountry/{countryCode}/{codeProvider}':
     get:
       parameters:
-      - name: countryCode
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      - name: codeProvider
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+        - name: countryCode
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: codeProvider
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
-        "200":
+        '200':
           description: 200 response
           content: {}
       security:
-      - api_key: []
-  /facilities/byName/{countryCode}:
+        - api_key: []
+  '/facilities/byName/{countryCode}':
     get:
       parameters:
-      - name: countryCode
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      - name: name
-        in: query
-        required: true
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: codeProvider
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
+        - name: countryCode
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: name
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: codeProvider
+          in: query
+          schema:
+            type: string
       responses:
-        "200":
+        '200':
           description: 200 response
           content: {}
       security:
-      - api_key: []
+        - api_key: []
   /facilities:
     post:
       requestBody:
@@ -75,131 +70,181 @@ paths:
               $ref: '#/components/schemas/Facility'
         required: true
       responses:
-        "200":
+        '200':
           description: 200 response
           content: {}
       security:
-      - AuthRequest: []
-      - api_key: []
-  /facilities/byLocation/{unLocode}/{codeProvider}:
+        - AuthRequest: []
+        - api_key: []
+  '/facilities/byLocation/{unLocode}/{codeProvider}':
     get:
       parameters:
-      - name: unLocode
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      - name: codeProvider
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+        - name: unLocode
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: codeProvider
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
-        "200":
+        '200':
           description: 200 response
           content: {}
       security:
-      - api_key: []
-  /facilities/{code}:
+        - api_key: []
+  '/facilities/{code}':
     get:
       parameters:
-      - name: code
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
+        - name: code
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
-        "200":
+        '200':
           description: 200 response
           content: {}
       security:
-      - api_key: []
+        - api_key: []
 components:
   schemas:
     Facility:
-      title: Facility
+      title: The root schema
       required:
-      - code
-      - codeProvider
-      - countryCode
-      - facility
-      - unLocode
+        - codeProvider
+        - countryCode
+        - facility
+        - unLocode
       type: object
       properties:
         code:
+          title: The code schema
           type: string
-          default: ""
+          description: The code used for identifying the specific facility.
+          default: ''
         codeProvider:
+          title: The codeProvider schema
           type: string
-          default: ""
-        countryCode:
+          description: 'The organization providing the code list, either BIC or SMDG.'
+          enum:
+            - BIC
+            - SMDG
+        codeListProviderCode:
+          title: The codeListProviderCode schema
           type: string
-          default: ""
+          description: >-
+            The code provided for the Facility by the code list provider. This
+            code does not need to be unique on its own.
+          default: ''
         unLocode:
+          title: The unLocode schema
+          maxLength: 5
+          minLength: 5
           type: string
-          default: ""
+          description: >-
+            The UN Location Code identifies a location in the sense of a city/a
+            town/a village, being the smaller administrative area existing as
+            defined by the competent national authority in each country.
+        countryCode:
+          title: The countryCode schema
+          maxLength: 2
+          minLength: 2
+          type: string
+          description: ''
         facility:
-          $ref: '#/components/schemas/Facility_facility'
-    Facility_facility_address:
-      required:
-      - city
-      - country
-      - postcode
-      - state
-      - street
-      type: object
-      properties:
-        country:
+          title: The facility schema
+          required:
+            - address
+            - formattedAddress
+            - geographicalCoordinate
+            - name
+          type: object
+          properties:
+            name:
+              title: The name schema
+              minLength: 1
+              type: string
+              description: The name of the facility.
+            address:
+              title: The address schema
+              required:
+                - city
+                - country
+                - postcode
+                - state
+                - street
+              type: object
+              properties:
+                street:
+                  title: The street schema
+                  type: string
+                  description: ''
+                  default: ''
+                city:
+                  title: The city schema
+                  type: string
+                  description: ''
+                  default: ''
+                state:
+                  title: The state schema
+                  type: string
+                  description: ''
+                  default: ''
+                postcode:
+                  title: The postcode schema
+                  type: string
+                  description: ''
+                  default: ''
+                country:
+                  title: The country schema
+                  type: string
+                  description: ''
+                  default: ''
+              description: The address of the facility.
+            formattedAddress:
+              title: The formattedAddress schema
+              type: string
+              description: ''
+              default: ''
+            geographicalCoordinate:
+              title: The geographicalCoordinate schema
+              required:
+                - latitude
+                - longitude
+              type: object
+              properties:
+                latitude:
+                  title: The latitude schema
+                  type: string
+                  description: ''
+                  default: ''
+                longitude:
+                  title: The longitude schema
+                  type: string
+                  description: ''
+                  default: ''
+              description: A geographic location identifier following ISO 6709.
+          description: ''
+        operator:
+          title: The operator schema
+          required:
+            - name
+          type: object
+          properties:
+            name:
+              title: The name schema
+              type: string
+              description: ''
+          description: ''
+        remarks:
+          title: The remarks schema
           type: string
-          default: ""
-        city:
-          type: string
-          default: ""
-        street:
-          type: string
-          default: ""
-        postcode:
-          type: string
-          default: ""
-        state:
-          type: string
-          default: ""
-    Facility_facility_geographicalCoordinate:
-      required:
-      - latitude
-      - longitude
-      type: object
-      properties:
-        latitude:
-          type: string
-          default: ""
-        longitude:
-          type: string
-          default: ""
-    Facility_facility:
-      required:
-      - address
-      - formattedAddress
-      - geographicalCoordinate
-      - name
-      type: object
-      properties:
-        address:
-          $ref: '#/components/schemas/Facility_facility_address'
-        formattedAddress:
-          type: string
-          default: ""
-        name:
-          type: string
-          default: ""
-        geographicalCoordinate:
-          $ref: '#/components/schemas/Facility_facility_geographicalCoordinate'
+          description: ''
+          default: ''
+      description: ''
   securitySchemes:
     AuthRequest:
       type: apiKey


### PR DESCRIPTION
This addresses issues #1 #2 and now SMDG codes will also return:

* `codeProviderCode` 
* `remarks`